### PR TITLE
Fix message formatting bugs in logger output

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -96,7 +96,7 @@ function formatPlaceholders(message, args) {
         return String(arg);
       }
       case '%d': {
-        return Number(arg);
+        return String(Number(arg));
       }
       case '%j': {
         try {
@@ -182,16 +182,16 @@ export class Logger {
       let formattedMessage = formatPlaceholders(message, args);
 
       const finalOutput = loggerConfig.format
-        .replace('%(date)s', timestamp)
-        .replace('%(levelname)s', upperLevel)
-        .replace('%(name)s', this.name)
-        .replace('%(message)s', formattedMessage);
+        .replace('%(date)s', () => timestamp)
+        .replace('%(levelname)s', () => upperLevel)
+        .replace('%(name)s', () => this.name)
+        .replace('%(message)s', () => formattedMessage);
 
       const consoleMethod = CONSOLE_METHOD_MAP[level] ?? 'log';
       console[consoleMethod](finalOutput);
 
     } catch (error) {
-      console.error('Could create the log message');
+      console.error('Could not create the log message');
       console.error(`${message} with the error ${error}`);
     }
   }

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -82,3 +82,43 @@ test('Take care of leftover arguments', t => {
   );
   t.true(captured.includes('123'), 'Should include leftover number');
 });
+
+test('Messages containing $-substitutions are emitted verbatim', t => {
+  configureLog({ verbose: 3 });
+  const logger = getLogger('format-test');
+
+  const captured = captureConsole('info', () => {
+    logger.info('price is $1 per unit ($$ raw, $& too)');
+  });
+
+  t.true(
+    captured.includes('price is $1 per unit ($$ raw, $& too)'),
+    'Should not interpret $1, $$, $& as String.replace specials'
+  );
+});
+
+test('Logger name with $-substitutions is emitted verbatim', t => {
+  configureLog({ verbose: 3 });
+  const logger = getLogger('name-with-$1-and-$&');
+
+  const captured = captureConsole('info', () => {
+    logger.info('hello');
+  });
+
+  t.true(
+    captured.includes('name-with-$1-and-$&'),
+    'Should not interpret $-tokens in the logger name'
+  );
+});
+
+test('%d formats as the numeric value', t => {
+  configureLog({ verbose: 3 });
+  const logger = getLogger('format-test');
+
+  const captured = captureConsole('info', () => {
+    logger.info('count=%d', 7);
+  });
+
+  t.true(captured.includes('count=7'), 'Should render the number');
+  t.false(captured.includes('count=NaN'), 'Should not render NaN');
+});


### PR DESCRIPTION
  Three small but user-visible bugs in the formatter:

  Log messages containing $1, $&, $$ or similar tokens were
  mangled because the final substitution in Logger.log used
  String.prototype.replace with a string replacement, and replace
  interprets those tokens as backreferences. Switching to replacer
  functions makes the message, logger name, level and timestamp all
  emit verbatim, which is what users expect from a log line.

  The %d placeholder returned a Number rather than a String,
  relying on implicit coercion inside the regex callback. That works
  today but is inconsistent with the other branches and easy to break
  in a future refactor.

  The catch-block fallback said "Could create the log message" — the
  "not" had been dropped.

  Co-authored-by: Claude noreply@anthropic.com